### PR TITLE
Monorepo + client & server shared interfaces

### DIFF
--- a/packages/client/src/components/Movies.tsx
+++ b/packages/client/src/components/Movies.tsx
@@ -1,17 +1,5 @@
 import * as React from 'react';
-
-interface IDirector {
-  readonly id: string;
-  readonly createdAt: string;
-  name: string;
-}
-
-interface IMovie {
-  readonly id: string;
-  readonly createdAt: string;
-  name: string;
-  readonly director: IDirector;
-}
+import { IMovie } from 'Interfaces/models/Movie';
 
 interface IMoviesProps {}
 

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -22,6 +22,8 @@
       "*": [
         "src/*"
       ],
+      // Satisfies Typescript module resolution and allows us to easily identify
+      // code imported from a sibling package
       "Interfaces/*": [
         "../interfaces/src/*"
       ]

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -21,6 +21,9 @@
     "paths": {
       "*": [
         "src/*"
+      ],
+      "Interfaces/*": [
+        "../interfaces/src/*"
       ]
     }
   },

--- a/packages/client/webpack.config.js
+++ b/packages/client/webpack.config.js
@@ -13,7 +13,10 @@ export default {
       src,
       node_modules
     ],
-    extensions: ['.ts', '.tsx', '.js']
+    extensions: ['.ts', '.tsx', '.js'],
+    alias: {
+      Interfaces: path.resolve(__dirname, '../interfaces/src/')
+    }
   },
   target: 'web',
   entry: {

--- a/packages/client/webpack.config.js
+++ b/packages/client/webpack.config.js
@@ -15,6 +15,9 @@ export default {
     ],
     extensions: ['.ts', '.tsx', '.js'],
     alias: {
+      // We need to also tell Webpack what the 'Interfaces/' import prefix
+      // means and where it maps to. Again, this is helpful in development,
+      // but we won't rely on this in production
       Interfaces: path.resolve(__dirname, '../interfaces/src/')
     }
   },

--- a/packages/interfaces/src/models/Director.ts
+++ b/packages/interfaces/src/models/Director.ts
@@ -1,3 +1,5 @@
+// An interface that matches the server's API response for a Director
+
 export interface IDirector {
   readonly id: string;
   readonly createdAt: string;

--- a/packages/interfaces/src/models/Director.ts
+++ b/packages/interfaces/src/models/Director.ts
@@ -1,0 +1,5 @@
+export interface IDirector {
+  readonly id: string;
+  readonly createdAt: string;
+  name: string;
+}

--- a/packages/interfaces/src/models/Movie.ts
+++ b/packages/interfaces/src/models/Movie.ts
@@ -1,0 +1,8 @@
+import { IDirector } from './Director';
+
+export interface IMovie {
+  readonly id: string;
+  readonly createdAt: string;
+  name: string;
+  readonly director: IDirector;
+}

--- a/packages/interfaces/src/models/Movie.ts
+++ b/packages/interfaces/src/models/Movie.ts
@@ -1,5 +1,6 @@
 import { IDirector } from './Director';
 
+// An interface that matches the server's API response for a Movie
 export interface IMovie {
   readonly id: string;
   readonly createdAt: string;

--- a/packages/server/src/models/Base.ts
+++ b/packages/server/src/models/Base.ts
@@ -25,8 +25,12 @@ abstract class Base extends Model {
     }
   }
 
+  // Force each server model to whitelist the attributes to include in an API response
   abstract getJsonAttributes(): Array<keyof this>;
 
+  // Form the API response of each model. Note we could use Lodash's 'pick' method,
+  // but it seems to skip ES6 'getters' for computed properties, which come in handy
+  // for extra customization of the API response
   $formatJson(json: Object): Object {
     const jsonObj: any = {};
     this.getJsonAttributes().forEach((attribute) => {

--- a/packages/server/src/models/Base.ts
+++ b/packages/server/src/models/Base.ts
@@ -24,6 +24,16 @@ abstract class Base extends Model {
       await Promise.resolve(Base.knexInstance.destroy());
     }
   }
+
+  abstract getJsonAttributes(): Array<keyof this>;
+
+  $formatJson(json: Object): Object {
+    const jsonObj: any = {};
+    this.getJsonAttributes().forEach((attribute) => {
+      jsonObj[attribute] = this[attribute];
+    });
+    return super.$formatJson(jsonObj);
+  }
 }
 
 export default Base;

--- a/packages/server/src/models/Director.ts
+++ b/packages/server/src/models/Director.ts
@@ -1,5 +1,6 @@
 import { RelationMappings } from 'objection';
 import Base from './Base';
+import { IDirector } from 'Interfaces/models/Director';
 
 export default class Director extends Base {
   static tableName = 'directors';
@@ -39,4 +40,9 @@ export default class Director extends Base {
   };
 
   name: string;
+
+  getJsonAttributes(): Array<keyof this> {
+    const attributes: Array<keyof IDirector> = ['id', 'createdAt', 'name'];
+    return attributes;
+  }
 }

--- a/packages/server/src/models/Director.ts
+++ b/packages/server/src/models/Director.ts
@@ -41,7 +41,15 @@ export default class Director extends Base {
 
   name: string;
 
+  // Force the response to be an array of strings that match keys of a server Director -
+  // e.g. the 'name' definition above
   getJsonAttributes(): Array<keyof this> {
+    // This might seem duplicative, but here, we force the array to be keys defined
+    // on the 'public' interface. This actually isn't duplicative though, as:
+    // 1) The typing on the function return type ensures Base.$formatJson can
+    //    simply 'pick' the value off the object/model
+    // 2) The typing on this array ensures we also obey the interface that the client
+    //    uses.
     const attributes: Array<keyof IDirector> = ['id', 'createdAt', 'name'];
     return attributes;
   }

--- a/packages/server/src/models/Movie.ts
+++ b/packages/server/src/models/Movie.ts
@@ -48,7 +48,15 @@ export default class Movie extends Base {
   director_id: string;
   readonly director: Director;
 
+  // Force the response to be an array of strings that match keys of a server Director -
+  // e.g. the 'name' definition above
   getJsonAttributes(): Array<keyof this> {
+    // This might seem duplicative, but here, we force the array to be keys defined
+    // on the 'public' interface. This actually isn't duplicative though, as:
+    // 1) The typing on the function return type ensures Base.$formatJson can
+    //    simply 'pick' the value off the object/model
+    // 2) The typing on this array ensures we also obey the interface that the client
+    //    uses.
     const attributes: Array<keyof IMovie> = ['id', 'createdAt', 'name', 'director'];
     return attributes;
   }

--- a/packages/server/src/models/Movie.ts
+++ b/packages/server/src/models/Movie.ts
@@ -1,5 +1,6 @@
 import Director from './Director';
 import Base from './Base';
+import { IMovie } from 'Interfaces/models/Movie';
 import { RelationMappings } from 'objection';
 
 export default class Movie extends Base {
@@ -46,4 +47,9 @@ export default class Movie extends Base {
   name: string;
   director_id: string;
   readonly director: Director;
+
+  getJsonAttributes(): Array<keyof this> {
+    const attributes: Array<keyof IMovie> = ['id', 'createdAt', 'name', 'director'];
+    return attributes;
+  }
 }

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -24,13 +24,14 @@
       "*": [
         "src/*"
       ],
+      // Satisfies Typescript module resolution and allows us to easily identify
+      // code imported from a sibling package
       "Interfaces/*": [
         "../interfaces/src/*"
       ]
     }
   },
   "include": [
-    "src/**/*",
-    "../interfaces/src/*"
+    "src/**/*"
   ]
 }

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -23,10 +23,14 @@
     "paths": {
       "*": [
         "src/*"
+      ],
+      "Interfaces/*": [
+        "../interfaces/src/*"
       ]
     }
   },
   "include": [
-    "src/**/*"
+    "src/**/*",
+    "../interfaces/src/*"
   ]
 }


### PR DESCRIPTION
## Summary
This moves hardcoded client interfaces that define the shape of an object received via the API to an ``Interfaces`` package that both the client and server can import from. We also ensure the server obeys the interface when forming API responses.

## Using ``Interfaces`` in sibling packages
While tools like **[Lerna](https://github.com/lerna/lerna)** help you manage and deploy a monorepo in a production setting, you can achieve a lot during development without it.

### Using ``Interfaces`` in the client
#### Configuring Typescript
Add a ``path`` to the ``interfaces`` package so that the Typescript compiler and IDEs know how to find the interfaces.

![screen shot 2017-06-07 at 3 29 52 pm](https://user-images.githubusercontent.com/811258/26897421-89f26ca6-4b96-11e7-8dd8-948a319aed51.png)

#### Configuring Webpack
Add an ``alias`` to the Webpack config so that Webpack can also resolve the path.

![screen shot 2017-06-07 at 3 33 39 pm](https://user-images.githubusercontent.com/811258/26897496-bb41e3fe-4b96-11e7-8f3b-c1b91f8737c3.png)

## Defining interfaces
This one's pretty straightforward! Simply move the hardcoded client ``interface`` to the new ``interfaces`` package. These interfaces define the format of API responses - **not** the format of the object on the server prior to being processed by the API.

![screen shot 2017-06-07 at 3 37 49 pm](https://user-images.githubusercontent.com/811258/26897664-4b98c5c6-4b97-11e7-908d-7a6b5c9359f1.png)

## Using interfaces on the client
With the above setup, using the interface on the client is as simple as:

![screen shot 2017-06-07 at 3 38 50 pm](https://user-images.githubusercontent.com/811258/26897708-6f19200e-4b97-11e7-8a2e-5294c0e26ede.png)

## Using (and obeying) interfaces in the server/API
This is the big one! As the client will simply be using the interface as-is, we need to ensure the API is indeed creating an object that obeys this interface. We can do this with a bit of clever hackery 😄 

### Force each model to use a consistent API to define their API response
Here, we use Typescript's support for ``abstract`` methods to force all models to whitelist the properties defined on the model to include in an API response.

![screen shot 2017-06-07 at 3 41 29 pm](https://user-images.githubusercontent.com/811258/26897863-f5223492-4b97-11e7-952a-7952c2186935.png)

Next, we implement a basic function to create the API response by 'picking' the properties whitelisted. Note that we use the [Objection ORM](http://vincit.github.io/objection.js) but something similar can likely be implemented with any setup.

![screen shot 2017-06-07 at 3 46 03 pm](https://user-images.githubusercontent.com/811258/26898005-74013c68-4b98-11e7-8c80-8af533deb5bb.png)

### Implement ``getJsonAttributes`` and ensure it obeys the shared ``interface``
Now, all we need to do is implement ``getJsonAttributes`` in each model. Given the above implementation of ``$formatJson``, we need to ensure 2 things:
1. Each property is defined on the model so it can be 'picked' in ``$formatJson``
2. Each property is defined on the shared interface that the client uses.

We can achieve both with Typescript's ``keyof`` operator.

![screen shot 2017-06-07 at 3 49 07 pm](https://user-images.githubusercontent.com/811258/26898147-e24a72b6-4b98-11e7-82fa-bd45565cc4ea.png)

That's it!