### PR TITLE
Typesafe Redux

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -14,12 +14,15 @@
     "@types/lodash": "^4.14.65",
     "@types/react": "^15.0.26",
     "@types/react-dom": "^15.5.0",
+    "@types/react-redux": "4.4.37",
+    "@types/redux-logger": "^3.0.0",
     "@types/webpack": "^2.2.15",
     "@types/webpack-dev-middleware": "^1.9.1",
     "@types/webpack-hot-middleware": "^2.15.0",
     "awesome-typescript-loader": "^3.1.3",
     "express": "^4.15.3",
     "open": "^0.0.5",
+    "redux-logger": "^3.0.6",
     "source-map-loader": "^0.2.1",
     "ts-node": "^3.0.4",
     "typescript": "^2.3.4",
@@ -30,6 +33,9 @@
   "dependencies": {
     "lodash": "^4.17.4",
     "react": "^15.5.4",
-    "react-dom": "^15.5.4"
+    "react-dom": "^15.5.4",
+    "react-redux": "5.0.3",
+    "redux": "^3.6.0",
+    "redux-thunk": "^2.2.0"
   }
 }

--- a/packages/client/src/actionTypes.ts
+++ b/packages/client/src/actionTypes.ts
@@ -1,0 +1,2 @@
+export const MOVIES_REQUEST = 'MOVIES_REQUEST';
+export const MOVIES_SUCCESS = 'MOVIES_SUCCESS';

--- a/packages/client/src/actions/index.ts
+++ b/packages/client/src/actions/index.ts
@@ -1,0 +1,28 @@
+import { MOVIES_REQUEST, MOVIES_SUCCESS } from 'actionTypes';
+import { IMovie } from 'Interfaces/models/Movie';
+
+export const loadMovies = () => (dispatch: any) => {
+  dispatch({
+    type: MOVIES_REQUEST
+  });
+
+  const fetchOptions: RequestInit = {
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    method: 'GET'
+  };
+
+  return fetch('http://localhost:5000/v1/movies', fetchOptions).then((response: Response) =>
+    response.json().then((movies: Array<IMovie>) => {
+      if (!response.ok) {
+        // TODO: Display error
+      }
+
+      dispatch({
+        type: MOVIES_SUCCESS,
+        movies
+      });
+    })
+  );
+};

--- a/packages/client/src/actions/index.ts
+++ b/packages/client/src/actions/index.ts
@@ -1,8 +1,20 @@
 import { MOVIES_REQUEST, MOVIES_SUCCESS } from 'actionTypes';
 import { IMovie } from 'Interfaces/models/Movie';
+import { Action, Dispatch } from 'redux';
 
-export const loadMovies = () => (dispatch: any) => {
-  dispatch({
+// Type 'type' for our Action to request and respond with
+// movies. Note that we use Redux typings and extend them
+// as need be
+export interface IMoviesAction extends Action {
+  movies?: Array<IMovie>;
+}
+
+export const loadMovies = () => (dispatch: Dispatch<IMoviesAction>) => {
+  const dispatchMovieAction = (action: IMoviesAction) => (
+    dispatch(action)
+  );
+
+  dispatchMovieAction({
     type: MOVIES_REQUEST
   });
 
@@ -19,7 +31,7 @@ export const loadMovies = () => (dispatch: any) => {
         // TODO: Display error
       }
 
-      dispatch({
+      dispatchMovieAction({
         type: MOVIES_SUCCESS,
         movies
       });

--- a/packages/client/src/components/Movies.tsx
+++ b/packages/client/src/components/Movies.tsx
@@ -1,49 +1,33 @@
 import * as React from 'react';
+import { connect } from 'react-redux';
 import { IMovie } from 'Interfaces/models/Movie';
+import { loadMovies } from '../actions';
+import { IReduxStore } from '../reducers';
 
-interface IMoviesProps {}
+interface IMoviesPassedProps {}
 
-interface IMoviesState {
+interface IMoviesConnectedProps {
+  movies?: Array<IMovie>;
   fetching: boolean;
-  movies: Array<IMovie>;
 }
 
-export default class Movies extends React.Component<IMoviesProps, IMoviesState> {
-  public state: IMoviesState = {
-    fetching: false,
-    movies: []
-  }
+interface IMoviesDispatchProps {
+  loadMovies: () => void;
+}
 
+type MoviesProps = IMoviesPassedProps & IMoviesConnectedProps & IMoviesDispatchProps;
+
+class Movies extends React.Component<MoviesProps, undefined> {
   public componentDidMount() {
-    const fetchOptions: RequestInit = {
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      method: 'GET'
-    };
+    const { loadMovies: dispatchLoadMovies } = this.props;
 
-    this.setState({
-      fetching: true
-    });
-
-    fetch('http://localhost:5000/v1/movies', fetchOptions).then((response: Response) =>
-      response.json().then((movies: Array<IMovie>) => {
-        if (!response.ok) {
-          // TODO: Display error
-        }
-
-        this.setState({
-          movies,
-          fetching: false
-        });
-      })
-    );
+    dispatchLoadMovies();
   }
 
   public render() {
-    const { fetching, movies } = this.state;
+    const { fetching, movies } = this.props;
 
-    if (fetching) {
+    if (fetching || !movies) {
       return <div>Loading...</div>
     };
 
@@ -60,3 +44,18 @@ export default class Movies extends React.Component<IMoviesProps, IMoviesState> 
     </li>
   );
 }
+
+const mapStateToProps = (
+  store: IReduxStore,
+  ownProps: IMoviesPassedProps
+): IMoviesConnectedProps => {
+  const { movies } = store;
+
+  return {
+    ...movies
+  };
+}
+
+export default connect(mapStateToProps, {
+  loadMovies
+})(Movies);

--- a/packages/client/src/components/Movies.tsx
+++ b/packages/client/src/components/Movies.tsx
@@ -45,6 +45,8 @@ class Movies extends React.Component<MoviesProps, undefined> {
   );
 }
 
+// We can gain typesafe access to our Redux store by simply
+// importing the 'parent' interface
 const mapStateToProps = (
   store: IReduxStore,
   ownProps: IMoviesPassedProps

--- a/packages/client/src/configureStore.ts
+++ b/packages/client/src/configureStore.ts
@@ -1,0 +1,18 @@
+import { createStore, applyMiddleware, compose } from 'redux';
+import thunk from 'redux-thunk';
+import rootReducer from './reducers';
+import * as ReduxLogger from 'redux-logger';
+
+const configureStore = (preloadedState?: any) => {
+  const store = createStore(
+    rootReducer,
+    preloadedState,
+    compose(
+      applyMiddleware(thunk, ReduxLogger.createLogger())
+    )
+  );
+
+  return store;
+};
+
+export default configureStore;

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -2,10 +2,16 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import Movies from './components/Movies';
 import App from './components/App';
+import { Provider } from 'react-redux';
+import configureStore from './configureStore';
+
+const store = configureStore();
 
 ReactDOM.render(
-  <App>
-    <Movies />
-  </App>,
+  <Provider store={store}>
+    <App>
+      <Movies />
+    </App>
+  </Provider>,
   document.getElementById('app')
 );

--- a/packages/client/src/reducers/index.ts
+++ b/packages/client/src/reducers/index.ts
@@ -2,7 +2,10 @@ import { Action } from 'redux';
 import { combineReducers } from 'redux';
 import { IMovie } from 'Interfaces/models/Movie';
 import { MOVIES_REQUEST, MOVIES_SUCCESS } from 'actionTypes';
+import { IMoviesAction } from '../actions';
 
+// The single interface for the entire Redux store. This
+// will simply consist of many 'child' interfaces
 export interface IReduxStore {
   movies: IMoviesState;
 }
@@ -12,10 +15,23 @@ interface IMoviesState {
   movies?: Array<IMovie>
 }
 
+// A Typescript 'type guard' to dynamically change the type of
+// the given parameter if it satisifies a condition.
+const actionIsAMovieAction = (action: Action): action is IMoviesAction => (
+  action.type === MOVIES_REQUEST || action.type === MOVIES_SUCCESS
+);
+
+// The 'movies' reducer to process a request and response for
+// movies. Note that the state is typesafe as is the action
+// (using a type guard)
 const movies = (
   state: IMoviesState = { fetching: false },
-  action: Action
+  action: Action | IMoviesAction
 ): IMoviesState => {
+  if (!actionIsAMovieAction(action)) {
+    return state;
+  }
+
   const { type } = action;
 
   switch (type) {
@@ -25,7 +41,7 @@ const movies = (
         fetching: true
       };
     case MOVIES_SUCCESS:
-      const movies = (action as any).movies;
+      const movies = action.movies;
       return {
         ...state,
         movies,

--- a/packages/client/src/reducers/index.ts
+++ b/packages/client/src/reducers/index.ts
@@ -1,0 +1,43 @@
+import { Action } from 'redux';
+import { combineReducers } from 'redux';
+import { IMovie } from 'Interfaces/models/Movie';
+import { MOVIES_REQUEST, MOVIES_SUCCESS } from 'actionTypes';
+
+export interface IReduxStore {
+  movies: IMoviesState;
+}
+
+interface IMoviesState {
+  fetching: boolean;
+  movies?: Array<IMovie>
+}
+
+const movies = (
+  state: IMoviesState = { fetching: false },
+  action: Action
+): IMoviesState => {
+  const { type } = action;
+
+  switch (type) {
+    case MOVIES_REQUEST:
+      return {
+        ...state,
+        fetching: true
+      };
+    case MOVIES_SUCCESS:
+      const movies = (action as any).movies;
+      return {
+        ...state,
+        movies,
+        fetching: false
+      };
+    default:
+      return state;
+  }
+};
+
+const rootReducer = combineReducers({
+  movies
+});
+
+export default rootReducer;

--- a/packages/client/src/reducers/index.ts
+++ b/packages/client/src/reducers/index.ts
@@ -4,15 +4,17 @@ import { IMovie } from 'Interfaces/models/Movie';
 import { MOVIES_REQUEST, MOVIES_SUCCESS } from 'actionTypes';
 import { IMoviesAction } from '../actions';
 
+// The interface for requesting and storing movies from the API
+interface IMoviesState {
+  fetching: boolean;
+  movies?: Array<IMovie>
+}
+
 // The single interface for the entire Redux store. This
 // will simply consist of many 'child' interfaces
 export interface IReduxStore {
   movies: IMoviesState;
-}
-
-interface IMoviesState {
-  fetching: boolean;
-  movies?: Array<IMovie>
+  // More nodes in our store, each with their own interface...
 }
 
 // A Typescript 'type guard' to dynamically change the type of

--- a/packages/client/yarn.lock
+++ b/packages/client/yarn.lock
@@ -39,9 +39,22 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-redux@4.4.37":
+  version "4.4.37"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-4.4.37.tgz#14489a999cdfb0a05fb5c2335fa6c3c3e7c89ed5"
+  dependencies:
+    "@types/react" "*"
+    redux "^3.6.0"
+
 "@types/react@*", "@types/react@^15.0.26":
   version "15.0.26"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-15.0.26.tgz#19d8969edcabb2aa6d10ccfba807e67a93a0a8f4"
+
+"@types/redux-logger@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/redux-logger/-/redux-logger-3.0.0.tgz#abe464fe812d03c3580ec56e6b5b375861439fca"
+  dependencies:
+    redux "^3.6.0"
 
 "@types/serve-static@*":
   version "1.7.31"
@@ -576,6 +589,10 @@ decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+deep-diff@^0.3.5:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
+
 deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
@@ -969,6 +986,10 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
+hoist-non-react-statics@^1.0.3:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
+
 hosted-git-info@^2.1.4:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.4.2.tgz#0076b9f46a270506ddbaaea56496897460612a67"
@@ -1032,6 +1053,12 @@ ini@~1.3.0:
 interpret@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.3.tgz#cbc35c62eeee73f19ab7b10a801511401afc0f90"
+
+invariant@^2.0.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
+  dependencies:
+    loose-envify "^1.0.0"
 
 invert-kv@^1.0.0:
   version "1.0.0"
@@ -1234,7 +1261,11 @@ loader-utils@^1.1.0:
     emojis-list "^2.0.0"
     json5 "^0.5.0"
 
-lodash@^4.14.0, lodash@^4.17.4:
+lodash-es@^4.2.0, lodash-es@^4.2.1:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
+
+lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -1682,6 +1713,16 @@ react-dom@^15.5.4:
     object-assign "^4.1.0"
     prop-types "~15.5.7"
 
+react-redux@5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.0.3.tgz#86c3b68d56e74294a42e2a740ab66117ef6c019f"
+  dependencies:
+    hoist-non-react-statics "^1.0.3"
+    invariant "^2.0.0"
+    lodash "^4.2.0"
+    lodash-es "^4.2.0"
+    loose-envify "^1.1.0"
+
 react@^15.5.4:
   version "15.5.4"
   resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
@@ -1726,6 +1767,25 @@ readdirp@^2.0.0:
     minimatch "^3.0.2"
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
+
+redux-logger@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
+  dependencies:
+    deep-diff "^0.3.5"
+
+redux-thunk@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"
+
+redux@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-3.6.0.tgz#887c2b3d0b9bd86eca2be70571c27654c19e188d"
+  dependencies:
+    lodash "^4.2.1"
+    lodash-es "^4.2.1"
+    loose-envify "^1.1.0"
+    symbol-observable "^1.0.2"
 
 regex-cache@^0.4.2:
   version "0.4.3"
@@ -1996,6 +2056,10 @@ supports-color@^3.1.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
     has-flag "^1.0.0"
+
+symbol-observable@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
 tapable@^0.2.5, tapable@~0.2.5:
   version "0.2.6"


### PR DESCRIPTION
## Summary
It's not uncommon to think that ensuring type-safety of an entire Redux store is unreasonable, but I don't buy that 😄 Here, we kickstart our use of Redux by showing how both Actions, Reducers, and the entire store can be completely typesafe. This isn't entirely scalable though - we'll worry about that next!

### Actions
Adding type safety to Redux Actions is pretty straightforward - simply define an interface that extends the default ``Action`` typing (which simply defines the ``type`` field) and decorate it with the extra data we'll be sending along with our Action.

*Note that we are using [``Thunks``](https://github.com/gaearon/redux-thunk) to dispatch asynchronous actions.*

<img width="728" alt="screen shot 2017-06-07 at 4 46 47 pm" src="https://user-images.githubusercontent.com/811258/26900665-f2b09560-4ba0-11e7-96e3-9c8f733257c8.png">

### Reducers and the Store
Since ``connect``ed components will receive the entire store, we need to add type-safety to the entire state tree, which sounds intimidating! We'll scale this type-safety next, but for now, we can get started by simply defining an interface for each node in the tree, reusing those interfaces to define the entire tree.

<img width="525" alt="screen shot 2017-06-07 at 4 51 49 pm" src="https://user-images.githubusercontent.com/811258/26900871-ad0e8480-4ba1-11e7-815f-d239207283eb.png">

Next, we need to define our reducer. Note that we ``import`` the interface for fetching/responding with movies and use it to potentially define the ``Action``.

<img width="515" alt="screen shot 2017-06-07 at 4 53 55 pm" src="https://user-images.githubusercontent.com/811258/26900981-1a901014-4ba2-11e7-94ed-a1bfe3ecfcb0.png">

We use a [type guard](https://basarat.gitbooks.io/typescript/docs/types/typeGuard.html) to both detect if the ``Action`` should be processed by this reducer as well as to 'dynamically' change the type of the Action. Thus, type guards exist at runtime.

<img width="609" alt="screen shot 2017-06-07 at 4 55 53 pm" src="https://user-images.githubusercontent.com/811258/26901064-79fd157e-4ba2-11e7-8434-973c7aa54bba.png">

Finally, we implement our reducer, ensuring it obeys the interface required by the Redux store.

<img width="507" alt="screen shot 2017-06-07 at 4 58 21 pm" src="https://user-images.githubusercontent.com/811258/26901115-9c99652e-4ba2-11e7-965f-2d27902c808f.png">

### ``connect``ed components
Now that our actions, reducers, and store are all typesafe, all that's left is to leverage that type-safety in components that ``connect`` to the Redux store. Doing so is pretty straightforward:
- Import the interface for your Redux store, use that in ``connect``
- Separate out interfaces for 'passed' props, ``connect``ed props, and action (dispatch) props. Reuse any store interfaces if need be.

<img width="670" alt="screen shot 2017-06-07 at 5 15 38 pm" src="https://user-images.githubusercontent.com/811258/26901775-fcbd220e-4ba4-11e7-8240-92d466599f11.png">

So, now if we break the type safety of any part of our Redux workflow, we'll get compiler errors!

![suwwkmqrld](https://user-images.githubusercontent.com/811258/26901896-4eb325cc-4ba5-11e7-9e5d-09a84597ef91.gif)
