### PR TITLE
Bonus! Client models

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.4",
+    "moment": "^2.18.1",
     "normalizr": "^3.2.3",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",

--- a/packages/client/src/components/Movies.tsx
+++ b/packages/client/src/components/Movies.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { IMovie } from 'Interfaces/models/Movie';
-import { IDirector } from 'Interfaces/models/Director';
+import IMovie from 'models/Movie';
+import IDirector from 'models/Director';
 import { loadMovies } from '../actions';
 import { IReduxStore } from '../reducers';
 
@@ -42,8 +42,7 @@ class Movies extends React.Component<MoviesProps, undefined> {
 
   private renderMovie = (movie: IMovie) => {
     const { directors } = this.props;
-    // TODO: We'll clean this up next :)
-    const director = directors[movie.director as any];
+    const director = directors[movie.director];
 
     return (
       <li key={movie.id}>

--- a/packages/client/src/models/Base.ts
+++ b/packages/client/src/models/Base.ts
@@ -1,0 +1,7 @@
+import * as Moment from 'moment';
+
+interface IBaseModel {
+  createdAtMoment: Moment.Moment;
+}
+
+export default IBaseModel;

--- a/packages/client/src/models/Director.ts
+++ b/packages/client/src/models/Director.ts
@@ -1,0 +1,8 @@
+import { IDirector as IAPIDirector } from 'Interfaces/models/Director';
+import IBaseModel from './Base';
+
+interface IDirector extends IAPIDirector, IBaseModel {
+  moviesCount: number;
+}
+
+export default IDirector;

--- a/packages/client/src/models/Movie.ts
+++ b/packages/client/src/models/Movie.ts
@@ -1,0 +1,6 @@
+import { IMovie as IAPIMovie } from 'Interfaces/models/Movie';
+import IBaseModel from './Base';
+
+interface IMovie extends IAPIMovie<string>, IBaseModel {}
+
+export default IMovie;

--- a/packages/client/src/reducers/entities.ts
+++ b/packages/client/src/reducers/entities.ts
@@ -1,5 +1,5 @@
-import { IMovie } from 'Interfaces/models/Movie';
-import { IDirector } from 'Interfaces/models/Director';
+import IMovie from 'models/Movie';
+import IDirector from 'models/Director';
 import { mergeWith, isArray } from 'lodash';
 import { isApiCallAction, IApiCallAction } from 'actions';
 import { Action } from 'redux';

--- a/packages/client/src/schemas.ts
+++ b/packages/client/src/schemas.ts
@@ -1,7 +1,35 @@
 import { schema } from 'normalizr';
+import { IMovie as IAPIMovie } from 'Interfaces/models/Movie';
+import { IDirector as IAPIDirector } from 'Interfaces/models/Director';
+import IMovie from 'models/Movie';
+import IDirector from 'models/Director';
+import IBaseModel from 'models/Base';
+import * as Moment from 'moment';
 
-const movieSchema = new schema.Entity('movies', {});
-const directorSchema = new schema.Entity('directors', {});
+interface IAPIModel {
+  createdAt: string;
+}
+
+const createBaseModel = <T extends IAPIModel>(apiObject: T): T & IBaseModel => {
+  const baseModel: IBaseModel = {
+    createdAtMoment: Moment(apiObject.createdAt)
+  };
+
+  return Object.assign({}, apiObject, baseModel);
+};
+
+const movieSchema = new schema.Entity('movies', {}, {
+  processStrategy: (entity: IAPIMovie<string>): IMovie => (
+    createBaseModel<IAPIMovie<string>>(entity)
+  )
+});
+
+const directorSchema = new schema.Entity('directors', {}, {
+  processStrategy: (entity: IAPIDirector): IDirector => ({
+    ...createBaseModel<IAPIDirector>(entity),
+    moviesCount: entity.movies ? entity.movies.length : 0
+  })
+});
 
 movieSchema.define({
   director: directorSchema

--- a/packages/client/yarn.lock
+++ b/packages/client/yarn.lock
@@ -1373,6 +1373,10 @@ minimist@^1.2.0:
   dependencies:
     minimist "0.0.8"
 
+moment@^2.18.1:
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"

--- a/packages/interfaces/src/models/Director.ts
+++ b/packages/interfaces/src/models/Director.ts
@@ -1,5 +1,8 @@
+import { IMovie } from './Movie';
+
 export interface IDirector {
   readonly id: string;
   readonly createdAt: string;
   name: string;
+  readonly movies?: Array<IMovie>;
 }

--- a/packages/interfaces/src/models/Movie.ts
+++ b/packages/interfaces/src/models/Movie.ts
@@ -1,8 +1,8 @@
 import { IDirector } from './Director';
 
-export interface IMovie {
+export interface IMovie<T = IDirector> {
   readonly id: string;
   readonly createdAt: string;
   name: string;
-  readonly director: IDirector;
+  readonly director: T;
 }

--- a/packages/server/src/models/Director.ts
+++ b/packages/server/src/models/Director.ts
@@ -1,6 +1,7 @@
 import { RelationMappings } from 'objection';
 import Base from './Base';
 import { IDirector } from 'Interfaces/models/Director';
+import Movie from './Movie';
 
 export default class Director extends Base {
   static tableName = 'directors';
@@ -40,6 +41,7 @@ export default class Director extends Base {
   };
 
   name: string;
+  readonly movies?: Array<Movie>;
 
   getJsonAttributes(): Array<keyof this> {
     const attributes: Array<keyof IDirector> = ['id', 'createdAt', 'name'];


### PR DESCRIPTION
Forcing the client to obey the server's defined interface for APIs only gets us so far - it's likely inevitable that we'll need to modify the API response a bit for client-only functionality. For example, the ``IMovie`` interface defines a director (rightfully) as a ``IDirector`` object. But once ``normalizr`` process the movie, the ``director`` property is changed from an ``IDirector`` to a ``string`` that is simply the ID of the director. 

This PR shows you how you can extend the API's interface with client only functionality and how you can use Typescript's new support for generic defaults to override the type definition of certain properties.